### PR TITLE
fix forward proxy auth

### DIFF
--- a/tunnel/freedom/client.go
+++ b/tunnel/freedom/client.go
@@ -120,5 +120,7 @@ func NewClient(ctx context.Context, _ tunnel.Client) (*Client, error) {
 		preferIPv4:   cfg.TCP.PreferIPV4,
 		forwardProxy: cfg.ForwardProxy.Enabled,
 		proxyAddr:    addr,
+		username:     cfg.ForwardProxy.Username,
+		password:     cfg.ForwardProxy.Password,
 	}, nil
 }


### PR DESCRIPTION
`cfg.ForwardProxy.Username` and `cfg.ForwardProxy.Password` are defined but not used