### PR TITLE
Chore: reduce lock

### DIFF
--- a/log/golog/golog.go
+++ b/log/golog/golog.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	terminal "golang.org/x/term"
@@ -38,7 +39,7 @@ type Logger struct {
 	timestamp bool
 	quiet     bool
 	buf       colorful.ColorBuffer
-	logLevel  int
+	logLevel  int32
 }
 
 // Prefix struct define plain and color byte
@@ -110,7 +111,7 @@ func New(out FdWriter) *Logger {
 func (l *Logger) SetLogLevel(level log.LogLevel) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.logLevel = int(level)
+	atomic.StoreInt32(&l.logLevel, int32(level))
 }
 
 func (l *Logger) SetOutput(w io.Writer) {
@@ -295,7 +296,7 @@ func (l *Logger) Output(depth int, prefix Prefix, data string) error {
 
 // Fatal print fatal message to output and quit the application with status 1
 func (l *Logger) Fatal(v ...interface{}) {
-	if l.logLevel <= 4 {
+	if atomic.LoadInt32(&l.logLevel) <= 4 {
 		l.Output(1, FatalPrefix, fmt.Sprintln(v...))
 	}
 	os.Exit(1)
@@ -304,7 +305,7 @@ func (l *Logger) Fatal(v ...interface{}) {
 // Fatalf print formatted fatal message to output and quit the application
 // with status 1
 func (l *Logger) Fatalf(format string, v ...interface{}) {
-	if l.logLevel <= 4 {
+	if atomic.LoadInt32(&l.logLevel) <= 4 {
 		l.Output(1, FatalPrefix, fmt.Sprintf(format, v...))
 	}
 	os.Exit(1)
@@ -312,70 +313,70 @@ func (l *Logger) Fatalf(format string, v ...interface{}) {
 
 // Error print error message to output
 func (l *Logger) Error(v ...interface{}) {
-	if l.logLevel <= 3 {
+	if atomic.LoadInt32(&l.logLevel) <= 3 {
 		l.Output(1, ErrorPrefix, fmt.Sprintln(v...))
 	}
 }
 
 // Errorf print formatted error message to output
 func (l *Logger) Errorf(format string, v ...interface{}) {
-	if l.logLevel <= 3 {
+	if atomic.LoadInt32(&l.logLevel) <= 3 {
 		l.Output(1, ErrorPrefix, fmt.Sprintf(format, v...))
 	}
 }
 
 // Warn print warning message to output
 func (l *Logger) Warn(v ...interface{}) {
-	if l.logLevel <= 2 {
+	if atomic.LoadInt32(&l.logLevel) <= 2 {
 		l.Output(1, WarnPrefix, fmt.Sprintln(v...))
 	}
 }
 
 // Warnf print formatted warning message to output
 func (l *Logger) Warnf(format string, v ...interface{}) {
-	if l.logLevel <= 2 {
+	if atomic.LoadInt32(&l.logLevel) <= 2 {
 		l.Output(1, WarnPrefix, fmt.Sprintf(format, v...))
 	}
 }
 
 // Info print informational message to output
 func (l *Logger) Info(v ...interface{}) {
-	if l.logLevel <= 1 {
+	if atomic.LoadInt32(&l.logLevel) <= 1 {
 		l.Output(1, InfoPrefix, fmt.Sprintln(v...))
 	}
 }
 
 // Infof print formatted informational message to output
 func (l *Logger) Infof(format string, v ...interface{}) {
-	if l.logLevel <= 1 {
+	if atomic.LoadInt32(&l.logLevel) <= 1 {
 		l.Output(1, InfoPrefix, fmt.Sprintf(format, v...))
 	}
 }
 
 // Debug print debug message to output if debug output enabled
 func (l *Logger) Debug(v ...interface{}) {
-	if l.logLevel == 0 {
+	if atomic.LoadInt32(&l.logLevel) == 0 {
 		l.Output(1, DebugPrefix, fmt.Sprintln(v...))
 	}
 }
 
 // Debugf print formatted debug message to output if debug output enabled
 func (l *Logger) Debugf(format string, v ...interface{}) {
-	if l.logLevel == 0 {
+	if atomic.LoadInt32(&l.logLevel) == 0 {
 		l.Output(1, DebugPrefix, fmt.Sprintf(format, v...))
 	}
 }
 
 // Trace print trace message to output if debug output enabled
 func (l *Logger) Trace(v ...interface{}) {
-	if l.logLevel == 0 {
+	if atomic.LoadInt32(&l.logLevel) == 0 {
 		l.Output(1, TracePrefix, fmt.Sprintln(v...))
 	}
 }
 
 // Tracef print formatted trace message to output if debug output enabled
 func (l *Logger) Tracef(format string, v ...interface{}) {
-	if l.logLevel == 0 {
+	if atomic.LoadInt32(&l.logLevel) == 0 {
 		l.Output(1, TracePrefix, fmt.Sprintf(format, v...))
 	}
 }

--- a/statistic/memory/memory.go
+++ b/statistic/memory/memory.go
@@ -114,15 +114,13 @@ func (u *User) GetSpeedLimit() (send, recv int) {
 	u.limiterLock.RLock()
 	defer u.limiterLock.RUnlock()
 
-	sendLimit := 0
-	recvLimit := 0
 	if u.sendLimiter != nil {
-		sendLimit = int(u.sendLimiter.Limit())
+		send = int(u.sendLimiter.Limit())
 	}
 	if u.recvLimiter != nil {
-		recvLimit = int(u.recvLimiter.Limit())
+		recv = int(u.recvLimiter.Limit())
 	}
-	return sendLimit, recvLimit
+	return
 }
 
 func (u *User) Hash() string {

--- a/tunnel/trojan/server.go
+++ b/tunnel/trojan/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sync/atomic"
 
 	"github.com/p4gefau1t/trojan-go/api"
 	"github.com/p4gefau1t/trojan-go/common"
@@ -36,20 +37,21 @@ func (c *InboundConn) Metadata() *tunnel.Metadata {
 
 func (c *InboundConn) Write(p []byte) (int, error) {
 	n, err := c.Conn.Write(p)
-	c.sent += uint64(n)
+	atomic.AddUint64(&c.sent, uint64(n))
 	c.user.AddTraffic(n, 0)
 	return n, err
 }
 
 func (c *InboundConn) Read(p []byte) (int, error) {
 	n, err := c.Conn.Read(p)
-	c.recv += uint64(n)
+	atomic.AddUint64(&c.recv, uint64(n))
 	c.user.AddTraffic(0, n)
 	return n, err
 }
 
 func (c *InboundConn) Close() error {
-	log.Info("user", c.hash, "from", c.Conn.RemoteAddr(), "tunneling to", c.metadata.Address, "closed", "sent:", common.HumanFriendlyTraffic(c.sent), "recv:", common.HumanFriendlyTraffic(c.recv))
+	log.Info("user", c.hash, "from", c.Conn.RemoteAddr(), "tunneling to", c.metadata.Address, "closed",
+		"sent:", common.HumanFriendlyTraffic(atomic.LoadUint64(&c.sent)), "recv:", common.HumanFriendlyTraffic(atomic.LoadUint64(&c.recv)))
 	c.user.DelIP(c.ip)
 	return c.Conn.Close()
 }


### PR DESCRIPTION
减少了statistic.memory中锁的使用，使用sync.Map和atomic包实现。
另外改用time.Ticker,可以减小一点带宽计算的误差。
@Loyalsoldier 