### PR TITLE
Fix(atomic panic): 64-bit fields must be 64-bit aligned on 32-bit systems

### DIFF
--- a/statistic/memory/memory.go
+++ b/statistic/memory/memory.go
@@ -17,12 +17,18 @@ import (
 const Name = "MEMORY"
 
 type User struct {
-	sent        uint64
-	recv        uint64
-	lastSent    uint64
-	lastRecv    uint64
-	sendSpeed   uint64
-	recvSpeed   uint64
+	// WARNING: do not change the order of these fields.
+	// 64-bit fields that use `sync/atomic` package functions
+	// must be 64-bit aligned on 32-bit systems.
+	// Reference: https://github.com/golang/go/issues/599
+	// Solution: https://github.com/golang/go/issues/11891#issuecomment-433623786
+	sent      uint64
+	recv      uint64
+	lastSent  uint64
+	lastRecv  uint64
+	sendSpeed uint64
+	recvSpeed uint64
+
 	hash        string
 	ipTable     sync.Map
 	ipNum       int32

--- a/tunnel/trojan/client.go
+++ b/tunnel/trojan/client.go
@@ -29,9 +29,15 @@ const (
 )
 
 type OutboundConn struct {
+	// WARNING: do not change the order of these fields.
+	// 64-bit fields that use `sync/atomic` package functions
+	// must be 64-bit aligned on 32-bit systems.
+	// Reference: https://github.com/golang/go/issues/599
+	// Solution: https://github.com/golang/go/issues/11891#issuecomment-433623786
+	sent uint64
+	recv uint64
+
 	metadata          *tunnel.Metadata
-	sent              uint64
-	recv              uint64
 	user              statistic.User
 	headerWrittenOnce sync.Once
 	net.Conn

--- a/tunnel/trojan/server.go
+++ b/tunnel/trojan/server.go
@@ -21,9 +21,15 @@ import (
 
 // InboundConn is a trojan inbound connection
 type InboundConn struct {
+	// WARNING: do not change the order of these fields.
+	// 64-bit fields that use `sync/atomic` package functions
+	// must be 64-bit aligned on 32-bit systems.
+	// Reference: https://github.com/golang/go/issues/599
+	// Solution: https://github.com/golang/go/issues/11891#issuecomment-433623786
+	sent uint64
+	recv uint64
+
 	net.Conn
-	sent     uint64
-	recv     uint64
 	auth     statistic.Authenticator
 	user     statistic.User
 	hash     string


### PR DESCRIPTION
Fix #357 

Reference: https://github.com/golang/go/issues/599 and https://golang.org/pkg/sync/atomic/#pkg-note-BUG
Solution: https://github.com/golang/go/issues/11891#issuecomment-433623786

cc @fregie 