### PR TITLE
Fix the bug that does not read geoip and geosite in config file

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -38,8 +38,12 @@ func GetAssetLocation(file string) string {
 		return file
 	}
 	if loc := os.Getenv("TROJAN_GO_LOCATION_ASSET"); loc != "" {
-		log.Debugf("env set: TROJAN_GO_LOCATION_ASSET=%s", loc)
-		return filepath.Join(loc, file)
+		absPath, err := filepath.Abs(loc)
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Debugf("env set: TROJAN_GO_LOCATION_ASSET=%s", absPath)
+		return filepath.Join(absPath, file)
 	}
 	return filepath.Join(GetProgramDir(), file)
 }

--- a/common/common.go
+++ b/common/common.go
@@ -34,6 +34,9 @@ func GetProgramDir() string {
 }
 
 func GetAssetLocation(file string) string {
+	if filepath.IsAbs(file) {
+		return file
+	}
 	if loc := os.Getenv("TROJAN_GO_LOCATION_ASSET"); loc != "" {
 		log.Debugf("env set: TROJAN_GO_LOCATION_ASSET=%s", loc)
 		return filepath.Join(loc, file)

--- a/tunnel/router/client.go
+++ b/tunnel/router/client.go
@@ -312,7 +312,7 @@ func NewClient(ctx context.Context, underlay tunnel.Client) (*Client, error) {
 	ipCode := loadCode(cfg, "geoip:")
 	for _, c := range ipCode {
 		code := c.code
-		cidrs, err := geodataLoader.LoadGeoIP(code)
+		cidrs, err := geodataLoader.LoadIP(cfg.Router.GeoIPFilename, code)
 		if err != nil {
 			log.Error(err)
 		} else {
@@ -341,7 +341,7 @@ func NewClient(ctx context.Context, underlay tunnel.Client) (*Client, error) {
 			continue
 		}
 
-		domainList, err := geodataLoader.LoadGeoSite(code)
+		domainList, err := geodataLoader.LoadSite(cfg.Router.GeoSiteFilename, code)
 		if err != nil {
 			log.Error(err)
 		} else {


### PR DESCRIPTION
Hi everyone,

I noticed that the current `GetAssetLocation`, `LoadIP` and `LoadSite` will ignore `geoip` and `geosite` items in the routing config.

Therefore here is my proposal on this section that:

1. When the user specify an absolute path, it is used;
2. When the user specify a relative path, follow the current routine to have it joint with the value specified in environment variable or (if that is not available) program directory.
3. There should be a functionality that allow relative path joint with the directory in which the config file is, but it may possibly conflict with current rule (that join relative path with the program file), so it requires further discussion on implementation.

I am looking forward to your ideas and feedback.

Regards,
Chinese White Dolphin