### PR TITLE
feat: 使用go-sqlite3实现数据持久化

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ COMMIT := `git rev-parse HEAD`
 PLATFORM := linux
 BUILD_DIR := build
 VAR_SETTING := -X $(PACKAGE_NAME)/constant.Version=$(VERSION) -X $(PACKAGE_NAME)/constant.Commit=$(COMMIT)
-GOBUILD = env CGO_ENABLED=0 $(GO_DIR)go build -tags "full" -trimpath -ldflags="-s -w -buildid= $(VAR_SETTING)" -o $(BUILD_DIR)
+GOBUILD = $(GO_DIR)go build -tags "full" -trimpath -ldflags="-s -w -buildid= $(VAR_SETTING)" -o $(BUILD_DIR)
 
 .PHONY: trojan-go release test
 normal: clean trojan-go

--- a/api/service/server.go
+++ b/api/service/server.go
@@ -102,34 +102,34 @@ func (s *ServerAPI) SetUsers(stream TrojanServerService_SetUsersServer) error {
 				break
 			}
 			if req.Status.SpeedLimit != nil {
-				valid, user := s.auth.AuthUser(req.Status.User.Hash)
-				if !valid {
-					err = common.NewError("failed to auth new user").Base(err)
-					continue
+				err = s.auth.SetUserSpeedLimit(req.Status.User.Hash, int(req.Status.SpeedLimit.DownloadSpeed), int(req.Status.SpeedLimit.UploadSpeed))
+				if err != nil {
+					break
 				}
-				if req.Status.SpeedLimit != nil {
-					user.SetSpeedLimit(int(req.Status.SpeedLimit.DownloadSpeed), int(req.Status.SpeedLimit.UploadSpeed))
-				}
-				if req.Status.TrafficTotal != nil {
-					user.SetTraffic(req.Status.TrafficTotal.DownloadTraffic, req.Status.TrafficTotal.UploadTraffic)
-				}
-				user.SetIPLimit(int(req.Status.IpLimit))
 			}
+			if req.Status.TrafficTotal != nil {
+				err = s.auth.SetUserTraffic(req.Status.User.Hash, req.Status.TrafficTotal.DownloadTraffic, req.Status.TrafficTotal.UploadTraffic)
+				if err != nil {
+					break
+				}
+			}
+			err = s.auth.SetUserIPLimit(req.Status.User.Hash, int(req.Status.IpLimit))
 		case SetUsersRequest_Delete:
 			err = s.auth.DelUser(req.Status.User.Hash)
 		case SetUsersRequest_Modify:
-			valid, user := s.auth.AuthUser(req.Status.User.Hash)
-			if !valid {
-				err = common.NewError("invalid user " + req.Status.User.Hash)
-			} else {
-				if req.Status.SpeedLimit != nil {
-					user.SetSpeedLimit(int(req.Status.SpeedLimit.DownloadSpeed), int(req.Status.SpeedLimit.UploadSpeed))
+			if req.Status.SpeedLimit != nil {
+				err = s.auth.SetUserSpeedLimit(req.Status.User.Hash, int(req.Status.SpeedLimit.DownloadSpeed), int(req.Status.SpeedLimit.UploadSpeed))
+				if err != nil {
+					break
 				}
-				if req.Status.TrafficTotal != nil {
-					user.SetTraffic(req.Status.TrafficTotal.DownloadTraffic, req.Status.TrafficTotal.UploadTraffic)
-				}
-				user.SetIPLimit(int(req.Status.IpLimit))
 			}
+			if req.Status.TrafficTotal != nil {
+				err = s.auth.SetUserTraffic(req.Status.User.Hash, req.Status.TrafficTotal.DownloadTraffic, req.Status.TrafficTotal.UploadTraffic)
+				if err != nil {
+					break
+				}
+			}
+			err = s.auth.SetUserIPLimit(req.Status.User.Hash, int(req.Status.IpLimit))
 		}
 		if err != nil {
 			stream.Send(&SetUsersResponse{
@@ -156,7 +156,7 @@ func (s *ServerAPI) ListUsers(req *ListUsersRequest, stream TrojanServerService_
 		err := stream.Send(&ListUsersResponse{
 			Status: &UserStatus{
 				User: &User{
-					Hash: user.Hash(),
+					Hash: user.GetHash(),
 				},
 				TrafficTotal: &Traffic{
 					DownloadTraffic: downloadTraffic,

--- a/common/error.go
+++ b/common/error.go
@@ -25,6 +25,10 @@ func NewError(info string) *Error {
 	}
 }
 
+func NewErrorf(format string, a ...interface{}) *Error {
+	return NewError(fmt.Sprintf(format, a...))
+}
+
 func Must(err error) {
 	if err != nil {
 		fmt.Println(err)

--- a/go.mod
+++ b/go.mod
@@ -20,4 +20,6 @@ require (
 	google.golang.org/grpc v1.38.0
 	google.golang.org/protobuf v1.26.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+	gorm.io/driver/sqlite v1.1.4
+	gorm.io/gorm v1.21.10
 )

--- a/go.sum
+++ b/go.sum
@@ -162,6 +162,11 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
 github.com/jhump/protoreflect v1.8.2 h1:k2xE7wcUomeqwY0LDCYA16y4WWfyTcMx5mKhk0d4ua0=
 github.com/jhump/protoreflect v1.8.2/go.mod h1:7GcYQDdMU/O/BBrl/cX6PNHpXh6cenjd8pneu5yW7Tg=
+github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
+github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
+github.com/jinzhu/now v1.1.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/jinzhu/now v1.1.2 h1:eVKgfIdy9b6zbWBMgFpfDPoAMifwSZagU9HmEU6zgiI=
+github.com/jinzhu/now v1.1.2/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
@@ -192,6 +197,8 @@ github.com/marten-seemann/qtls-go1-16 v0.1.3 h1:XEZ1xGorVy9u+lJq+WXNE+hiqRYLNvJG
 github.com/marten-seemann/qtls-go1-16 v0.1.3/go.mod h1:gNpI2Ol+lRS3WwSOtIUUtRwZEQMXjYK+dQSBFbethAk=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-sqlite3 v1.14.5 h1:1IdxlwTNazvbKJQSxoJ5/9ECbEeaTTyeU7sEAZ5KKTQ=
+github.com/mattn/go-sqlite3 v1.14.5/go.mod h1:WVKg1VTActs4Qso6iwGbiFih2UIHo0ENGwNd0Lj+XmI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -573,6 +580,11 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gorm.io/driver/sqlite v1.1.4 h1:PDzwYE+sI6De2+mxAneV9Xs11+ZyKV6oxD3wDGkaNvM=
+gorm.io/driver/sqlite v1.1.4/go.mod h1:mJCeTFr7+crvS+TRnWc5Z3UvwxUN1BGBLMrf5LA9DYw=
+gorm.io/gorm v1.20.7/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=
+gorm.io/gorm v1.21.10 h1:kBGiBsaqOQ+8f6S2U6mvGFz6aWWyCeIiuaFcaBozp4M=
+gorm.io/gorm v1.21.10/go.mod h1:F+OptMscr0P2F2qU97WT1WimdH9GaQPoDW7AYd5i2Y0=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=
 h12.io/socks v1.0.2/go.mod h1:AIhxy1jOId/XCz9BO+EIgNL2rQiPTBNnOfnVnQ+3Eck=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/statistic/memory/config.go
+++ b/statistic/memory/config.go
@@ -6,6 +6,7 @@ import (
 
 type Config struct {
 	Passwords []string `json:"password" yaml:"password"`
+	Sqlite    string   `json:"sqlite" yaml:"sqlite"`
 }
 
 func init() {

--- a/statistic/memory/memory.go
+++ b/statistic/memory/memory.go
@@ -12,6 +12,7 @@ import (
 	"github.com/p4gefau1t/trojan-go/config"
 	"github.com/p4gefau1t/trojan-go/log"
 	"github.com/p4gefau1t/trojan-go/statistic"
+	"github.com/p4gefau1t/trojan-go/statistic/sqlite"
 )
 
 const Name = "MEMORY"
@@ -22,20 +23,19 @@ type User struct {
 	// must be 64-bit aligned on 32-bit systems.
 	// Reference: https://github.com/golang/go/issues/599
 	// Solution: https://github.com/golang/go/issues/11891#issuecomment-433623786
-	sent      uint64
-	recv      uint64
-	lastSent  uint64
-	lastRecv  uint64
-	sendSpeed uint64
-	recvSpeed uint64
-
-	hash        string
+	Sent        uint64
+	Recv        uint64
+	lastSent    uint64
+	lastRecv    uint64
+	sendSpeed   uint64
+	recvSpeed   uint64
+	Hash        string
 	ipTable     sync.Map
 	ipNum       int32
-	maxIPNum    int
+	MaxIPNum    int
 	limiterLock sync.RWMutex
-	sendLimiter *rate.Limiter
-	recvLimiter *rate.Limiter
+	SendLimiter *rate.Limiter
+	RecvLimiter *rate.Limiter
 	ctx         context.Context
 	cancel      context.CancelFunc
 }
@@ -47,14 +47,14 @@ func (u *User) Close() error {
 }
 
 func (u *User) AddIP(ip string) bool {
-	if u.maxIPNum <= 0 {
+	if u.MaxIPNum <= 0 {
 		return true
 	}
 	_, found := u.ipTable.Load(ip)
 	if found {
 		return true
 	}
-	if int(u.ipNum)+1 > u.maxIPNum {
+	if int(u.ipNum)+1 > u.MaxIPNum {
 		return false
 	}
 	u.ipTable.Store(ip, true)
@@ -63,7 +63,7 @@ func (u *User) AddIP(ip string) bool {
 }
 
 func (u *User) DelIP(ip string) bool {
-	if u.maxIPNum <= 0 {
+	if u.MaxIPNum <= 0 {
 		return true
 	}
 	_, found := u.ipTable.Load(ip)
@@ -79,25 +79,25 @@ func (u *User) GetIP() int {
 	return int(u.ipNum)
 }
 
-func (u *User) SetIPLimit(n int) {
-	u.maxIPNum = n
+func (u *User) setIPLimit(n int) {
+	u.MaxIPNum = n
 }
 
 func (u *User) GetIPLimit() int {
-	return u.maxIPNum
+	return u.MaxIPNum
 }
 
 func (u *User) AddTraffic(sent, recv int) {
 	u.limiterLock.RLock()
 	defer u.limiterLock.RUnlock()
 
-	if u.sendLimiter != nil && sent >= 0 {
-		u.sendLimiter.WaitN(u.ctx, sent)
-	} else if u.recvLimiter != nil && recv >= 0 {
-		u.recvLimiter.WaitN(u.ctx, recv)
+	if u.SendLimiter != nil && sent >= 0 {
+		u.SendLimiter.WaitN(u.ctx, sent)
+	} else if u.RecvLimiter != nil && recv >= 0 {
+		u.RecvLimiter.WaitN(u.ctx, recv)
 	}
-	atomic.AddUint64(&u.sent, uint64(sent))
-	atomic.AddUint64(&u.recv, uint64(recv))
+	atomic.AddUint64(&u.Sent, uint64(sent))
+	atomic.AddUint64(&u.Recv, uint64(recv))
 }
 
 func (u *User) SetSpeedLimit(send, recv int) {
@@ -105,14 +105,14 @@ func (u *User) SetSpeedLimit(send, recv int) {
 	defer u.limiterLock.Unlock()
 
 	if send <= 0 {
-		u.sendLimiter = nil
+		u.SendLimiter = nil
 	} else {
-		u.sendLimiter = rate.NewLimiter(rate.Limit(send), send*2)
+		u.SendLimiter = rate.NewLimiter(rate.Limit(send), send*2)
 	}
 	if recv <= 0 {
-		u.recvLimiter = nil
+		u.RecvLimiter = nil
 	} else {
-		u.recvLimiter = rate.NewLimiter(rate.Limit(recv), recv*2)
+		u.RecvLimiter = rate.NewLimiter(rate.Limit(recv), recv*2)
 	}
 }
 
@@ -120,31 +120,31 @@ func (u *User) GetSpeedLimit() (send, recv int) {
 	u.limiterLock.RLock()
 	defer u.limiterLock.RUnlock()
 
-	if u.sendLimiter != nil {
-		send = int(u.sendLimiter.Limit())
+	if u.SendLimiter != nil {
+		send = int(u.SendLimiter.Limit())
 	}
-	if u.recvLimiter != nil {
-		recv = int(u.recvLimiter.Limit())
+	if u.RecvLimiter != nil {
+		recv = int(u.RecvLimiter.Limit())
 	}
 	return
 }
 
-func (u *User) Hash() string {
-	return u.hash
+func (u *User) GetHash() string {
+	return u.Hash
 }
 
-func (u *User) SetTraffic(send, recv uint64) {
-	atomic.StoreUint64(&u.sent, send)
-	atomic.StoreUint64(&u.recv, recv)
+func (u *User) setTraffic(send, recv uint64) {
+	atomic.StoreUint64(&u.Sent, send)
+	atomic.StoreUint64(&u.Recv, recv)
 }
 
 func (u *User) GetTraffic() (uint64, uint64) {
-	return atomic.LoadUint64(&u.sent), atomic.LoadUint64(&u.recv)
+	return atomic.LoadUint64(&u.Sent), atomic.LoadUint64(&u.Recv)
 }
 
 func (u *User) ResetTraffic() (uint64, uint64) {
-	sent := atomic.SwapUint64(&u.sent, 0)
-	recv := atomic.SwapUint64(&u.recv, 0)
+	sent := atomic.SwapUint64(&u.Sent, 0)
+	recv := atomic.SwapUint64(&u.Recv, 0)
 	atomic.StoreUint64(&u.lastSent, 0)
 	atomic.StoreUint64(&u.lastRecv, 0)
 	return sent, recv
@@ -172,6 +172,7 @@ func (u *User) GetSpeed() (uint64, uint64) {
 
 type Authenticator struct {
 	users sync.Map
+	pst   statistic.Persistencer
 	ctx   context.Context
 }
 
@@ -188,12 +189,18 @@ func (a *Authenticator) AddUser(hash string) error {
 	}
 	ctx, cancel := context.WithCancel(a.ctx)
 	meter := &User{
-		hash:   hash,
+		Hash:   hash,
 		ctx:    ctx,
 		cancel: cancel,
 	}
 	go meter.speedUpdater()
 	a.users.Store(hash, meter)
+	if a.pst != nil {
+		err := a.pst.SaveUser(meter)
+		if err != nil {
+			log.Errorf("Save user %s failed: %s", hash, err)
+		}
+	}
 	return nil
 }
 
@@ -204,6 +211,9 @@ func (a *Authenticator) DelUser(hash string) error {
 	}
 	meter.(*User).Close()
 	a.users.Delete(hash)
+	if a.pst != nil {
+		a.pst.DeleteUser(hash)
+	}
 	return nil
 }
 
@@ -220,17 +230,92 @@ func (a *Authenticator) Close() error {
 	return nil
 }
 
+func (a *Authenticator) SetUserTraffic(hash string, sent, recv uint64) error {
+	u, exist := a.users.Load(hash)
+	if !exist {
+		return common.NewErrorf("user %v not found", hash)
+	}
+	user := u.(*User)
+	user.setTraffic(sent, recv)
+	if a.pst != nil {
+		err := a.pst.SaveUser(user)
+		if err != nil {
+			log.Errorf("Save user %s failed: %s", hash, err)
+		}
+	}
+	return nil
+}
+
+func (a *Authenticator) SetUserSpeedLimit(hash string, send, recv int) error {
+	u, exist := a.users.Load(hash)
+	if !exist {
+		return common.NewErrorf("user %v not found", hash)
+	}
+	user := u.(*User)
+	user.SetSpeedLimit(send, recv)
+	if a.pst != nil {
+		err := a.pst.SaveUser(user)
+		if err != nil {
+			log.Errorf("Save user %s failed: %s", hash, err)
+		}
+	}
+	return nil
+}
+
+func (a *Authenticator) SetUserIPLimit(hash string, limit int) error {
+	u, exist := a.users.Load(hash)
+	if !exist {
+		return common.NewErrorf("user %v not found", hash)
+	}
+	user := u.(*User)
+	user.setIPLimit(limit)
+	if a.pst != nil {
+		err := a.pst.SaveUser(user)
+		if err != nil {
+			log.Errorf("Save user %s failed: %s", hash, err)
+		}
+	}
+	return nil
+}
+
 func NewAuthenticator(ctx context.Context) (statistic.Authenticator, error) {
 	cfg := config.FromContext(ctx, Name).(*Config)
-	u := &Authenticator{
+	a := &Authenticator{
 		ctx: ctx,
+	}
+	var err error
+	if cfg.Sqlite != "" {
+		a.pst, err = sqlite.NewSqlitePersistencer(cfg.Sqlite)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if a.pst != nil {
+		err := a.pst.ListUser(func(hash string, u statistic.Metadata) bool {
+			if _, found := a.users.Load(hash); found {
+				log.Error("hash " + hash + " is already exist")
+				return true
+			}
+			ctx, cancel := context.WithCancel(a.ctx)
+			user := &User{
+				Hash:   hash,
+				ctx:    ctx,
+				cancel: cancel,
+			}
+			go user.speedUpdater()
+			a.users.Store(hash, user)
+			return true
+		})
+		if err != nil {
+			log.Errorf("List user from persistencer: %s", err)
+		}
 	}
 	for _, password := range cfg.Passwords {
 		hash := common.SHA224String(password)
-		u.AddUser(hash)
+		a.AddUser(hash)
 	}
 	log.Debug("memory authenticator created")
-	return u, nil
+	return a, nil
 }
 
 func init() {

--- a/statistic/memory/memory_test.go
+++ b/statistic/memory/memory_test.go
@@ -23,7 +23,7 @@ func TestMemoryAuth(t *testing.T) {
 	if !valid {
 		t.Fatal("add, auth")
 	}
-	if user.Hash() != "user1" {
+	if user.GetHash() != "user1" {
 		t.Fatal("Hash")
 	}
 	user.AddTraffic(100, 200)
@@ -46,7 +46,7 @@ func TestMemoryAuth(t *testing.T) {
 		t.Fatal("GetIP")
 	}
 
-	user.SetIPLimit(2)
+	auth.SetUserIPLimit(user.GetHash(), 2)
 	user.AddIP("1234")
 	user.AddIP("5678")
 	user.DelIP("1234")
@@ -55,7 +55,7 @@ func TestMemoryAuth(t *testing.T) {
 	}
 	user.DelIP("5678")
 
-	user.SetIPLimit(2)
+	auth.SetUserIPLimit(user.GetHash(), 2)
 	if !user.AddIP("1") || !user.AddIP("2") {
 		t.Fatal("AddIP")
 	}
@@ -66,7 +66,7 @@ func TestMemoryAuth(t *testing.T) {
 		t.Fatal("AddIP")
 	}
 
-	user.SetTraffic(1234, 4321)
+	auth.SetUserTraffic(user.GetHash(), 1234, 4321)
 	if a, b := user.GetTraffic(); a != 1234 || b != 4321 {
 		t.Fatal("SetTraffic")
 	}
@@ -86,7 +86,7 @@ func TestMemoryAuth(t *testing.T) {
 		t.Log("GetSpeed", sent, recv)
 	}
 
-	user.SetSpeedLimit(30, 20)
+	auth.SetUserSpeedLimit(user.GetHash(), 30, 20)
 	time.Sleep(time.Second * 4)
 	if sent, recv := user.GetSpeed(); sent > 60 || recv > 40 {
 		t.Error("SetSpeedLimit", sent, recv)
@@ -94,7 +94,7 @@ func TestMemoryAuth(t *testing.T) {
 		t.Log("SetSpeedLimit", sent, recv)
 	}
 
-	user.SetSpeedLimit(0, 0)
+	auth.SetUserSpeedLimit(user.GetHash(), 0, 0)
 	time.Sleep(time.Second * 4)
 	if sent, recv := user.GetSpeed(); sent < 30 || recv < 20 {
 		t.Error("SetSpeedLimit", sent, recv)

--- a/statistic/mysql/mysql.go
+++ b/statistic/mysql/mysql.go
@@ -30,7 +30,7 @@ func (a *Authenticator) updater() {
 	for {
 		for _, user := range a.ListUsers() {
 			// swap upload and download for users
-			hash := user.Hash()
+			hash := user.GetHash()
 			sent, recv := user.ResetTraffic()
 
 			s, err := a.db.Exec("UPDATE `users` SET `upload`=`upload`+?, `download`=`download`+? WHERE `password`=?;", recv, sent, hash)

--- a/statistic/sqlite/sqlite.go
+++ b/statistic/sqlite/sqlite.go
@@ -1,0 +1,100 @@
+package sqlite
+
+import (
+	"errors"
+
+	"github.com/p4gefau1t/trojan-go/statistic"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const Name = "sqlite"
+
+type Persistencer struct {
+	db *gorm.DB
+}
+
+func NewSqlitePersistencer(path string) (*Persistencer, error) {
+	db, err := gorm.Open(sqlite.Open(path), &gorm.Config{})
+	if err != nil {
+		return nil, err
+	}
+	err = db.AutoMigrate(&User{})
+	if err != nil {
+		return nil, err
+	}
+	sp := &Persistencer{
+		db: db,
+	}
+
+	return sp, nil
+}
+
+func (p *Persistencer) SaveUser(u statistic.Metadata) error {
+	if u == nil {
+		return errors.New("user is nil")
+	}
+	ls, lr := u.GetSpeedLimit()
+	usr := &User{
+		Hash:      u.GetHash(),
+		MaxIPNum:  u.GetIPLimit(),
+		SendLimit: ls,
+		RecvLimit: lr,
+		Sent:      make([]byte, 8),
+		Recv:      make([]byte, 8),
+	}
+	ts, tr := u.GetTraffic()
+	usr.setSent(ts)
+	usr.setRecv(tr)
+	err := p.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "hash"}},
+		UpdateAll: true,
+	}).Create(usr).Error
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *Persistencer) LoadUser(hash string) (statistic.Metadata, error) {
+	var u User
+	err := p.db.First(&u, "hash = ?", hash).Error
+	if err != nil {
+		return nil, err
+	}
+	return &u, nil
+}
+
+func (p *Persistencer) DeleteUser(hash string) error {
+	err := p.db.Delete(&User{Hash: hash}).Error
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *Persistencer) ListUser(f func(hash string, u statistic.Metadata) bool) error {
+	users := make([]User, 0)
+	err := p.db.Find(&users).Error
+	if err != nil {
+		return err
+	}
+	for _, u := range users {
+		if goOn := f(u.Hash, &u); !goOn {
+			break
+		}
+	}
+	return nil
+}
+
+func (p *Persistencer) UpdateUserTraffic(hash string, sent, recv uint64) error {
+	u := &User{
+		Hash: hash,
+		Sent: make([]byte, 8),
+		Recv: make([]byte, 8),
+	}
+	u.setSent(sent)
+	u.setRecv(recv)
+	return p.db.Model(&User{Hash: hash}).Updates(u).Error
+}

--- a/statistic/sqlite/user.go
+++ b/statistic/sqlite/user.go
@@ -13,17 +13,17 @@ type User struct {
 }
 
 func (u *User) setSent(sent uint64) {
-	binary.BigEndian.PutUint64(u.Sent[:], sent)
+	binary.BigEndian.PutUint64(u.Sent, sent)
 }
 func (u *User) getSent() uint64 {
-	return binary.BigEndian.Uint64(u.Sent[:])
+	return binary.BigEndian.Uint64(u.Sent)
 }
 
 func (u *User) setRecv(recv uint64) {
-	binary.BigEndian.PutUint64(u.Recv[:], recv)
+	binary.BigEndian.PutUint64(u.Recv, recv)
 }
 func (u *User) getRecv() uint64 {
-	return binary.BigEndian.Uint64(u.Recv[:])
+	return binary.BigEndian.Uint64(u.Recv)
 }
 
 func (u *User) GetHash() string {

--- a/statistic/sqlite/user.go
+++ b/statistic/sqlite/user.go
@@ -1,12 +1,14 @@
 package sqlite
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+)
 
 type User struct {
 	Hash string `gorm:"primary_key"`
 	// uint64 = 8 byte binary
-	Sent      []byte
-	Recv      []byte
+	Sent      []byte `gorm:"type:TEXT"`
+	Recv      []byte `gorm:"type:TEXT"`
 	MaxIPNum  int
 	SendLimit int
 	RecvLimit int

--- a/statistic/sqlite/user.go
+++ b/statistic/sqlite/user.go
@@ -1,0 +1,43 @@
+package sqlite
+
+import "encoding/binary"
+
+type User struct {
+	Hash string `gorm:"primary_key"`
+	// uint64 = 8 byte binary
+	Sent      []byte
+	Recv      []byte
+	MaxIPNum  int
+	SendLimit int
+	RecvLimit int
+}
+
+func (u *User) setSent(sent uint64) {
+	binary.BigEndian.PutUint64(u.Sent[:], sent)
+}
+func (u *User) getSent() uint64 {
+	return binary.BigEndian.Uint64(u.Sent[:])
+}
+
+func (u *User) setRecv(recv uint64) {
+	binary.BigEndian.PutUint64(u.Recv[:], recv)
+}
+func (u *User) getRecv() uint64 {
+	return binary.BigEndian.Uint64(u.Recv[:])
+}
+
+func (u *User) GetHash() string {
+	return u.Hash
+}
+
+func (u *User) GetTraffic() (sent, recv uint64) {
+	return u.getSent(), u.getRecv()
+}
+
+func (u *User) GetSpeedLimit() (sent, recv int) {
+	return u.SendLimit, u.RecvLimit
+}
+
+func (u *User) GetIPLimit() int {
+	return u.MaxIPNum
+}

--- a/statistic/statistics.go
+++ b/statistic/statistics.go
@@ -10,29 +10,40 @@ import (
 	"github.com/p4gefau1t/trojan-go/log"
 )
 
+const Name = "STATISTICS"
+
+type Metadata interface {
+	GetHash() string
+	GetTraffic() (sent, recv uint64)
+	GetSpeedLimit() (sent, recv int)
+	GetIPLimit() int
+}
+
 type TrafficMeter interface {
 	io.Closer
-	Hash() string
 	AddTraffic(sent, recv int)
-	GetTraffic() (sent, recv uint64)
-	SetTraffic(sent, recv uint64)
 	ResetTraffic() (sent, recv uint64)
 	GetSpeed() (sent, recv uint64)
-	GetSpeedLimit() (sent, recv int)
-	SetSpeedLimit(sent, recv int)
 }
 
 type IPRecorder interface {
 	AddIP(string) bool
 	DelIP(string) bool
 	GetIP() int
-	SetIPLimit(int)
-	GetIPLimit() int
 }
 
 type User interface {
+	Metadata
 	TrafficMeter
 	IPRecorder
+}
+
+type Persistencer interface {
+	SaveUser(Metadata) error
+	LoadUser(hash string) (Metadata, error)
+	DeleteUser(hash string) error
+	ListUser(func(hash string, u Metadata) bool) error
+	UpdateUserTraffic(hash string, sent, recv uint64) error
 }
 
 type Authenticator interface {
@@ -40,6 +51,9 @@ type Authenticator interface {
 	AuthUser(hash string) (valid bool, user User)
 	AddUser(hash string) error
 	DelUser(hash string) error
+	SetUserTraffic(hash string, sent, recv uint64) error
+	SetUserSpeedLimit(hash string, send, recv int) error
+	SetUserIPLimit(hash string, limit int) error
 	ListUsers() []User
 }
 

--- a/test/scenario/proxy_test.go
+++ b/test/scenario/proxy_test.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/p4gefau1t/trojan-go/proxy/server"
 	_ "github.com/p4gefau1t/trojan-go/statistic/memory"
 	"github.com/p4gefau1t/trojan-go/test/util"
+	"github.com/p4gefau1t/trojan-go/tunnel/trojan"
 )
 
 // test key and cert
@@ -86,6 +87,7 @@ func init() {
 }
 
 func CheckClientServer(clientData, serverData string, socksPort int) (ok bool) {
+	trojan.Auth = nil
 	server, err := proxy.NewProxyFromConfigData([]byte(serverData), false)
 	common.Must(err)
 	go server.Run()

--- a/tunnel/trojan/client.go
+++ b/tunnel/trojan/client.go
@@ -51,7 +51,7 @@ func (c *OutboundConn) WriteHeader(payload []byte) (bool, error) {
 	var err error
 	written := false
 	c.headerWrittenOnce.Do(func() {
-		hash := c.user.Hash()
+		hash := c.user.GetHash()
 		buf := bytes.NewBuffer(make([]byte, 0, MaxPacketSize))
 		crlf := []byte{0x0d, 0x0a}
 		buf.Write([]byte(hash))


### PR DESCRIPTION
为staticstics增加了一个数据持久化层，在修改用户信息的时候会向sqlite数据库中同时修改，定期更新user traffic信息。
需要注意的是，go-sqlite3库使用了cgo和动态链接库，所以需要开启cgo编译，且运行依赖动态链接库，我觉得这并不怎么好，有没有好的建议？
另外，如果不合入 PR #351 ,则会因为运行时存在多个auth实例而产生bug。
@Loyalsoldier @p4gefau1t 