### PR TITLE
feature: support specify buffer size in config

### DIFF
--- a/proxy/config.go
+++ b/proxy/config.go
@@ -3,15 +3,17 @@ package proxy
 import "github.com/p4gefau1t/trojan-go/config"
 
 type Config struct {
-	RunType  string `json:"run_type" yaml:"run-type"`
-	LogLevel int    `json:"log_level" yaml:"log-level"`
-	LogFile  string `json:"log_file" yaml:"log-file"`
+	RunType         string `json:"run_type" yaml:"run-type"`
+	LogLevel        int    `json:"log_level" yaml:"log-level"`
+	LogFile         string `json:"log_file" yaml:"log-file"`
+	RelayBufferSize int    `json:"relay_buffer_size" yaml:"relay_buffer_size"`
 }
 
 func init() {
 	config.RegisterConfigCreator(Name, func() interface{} {
 		return &Config{
-			LogLevel: 1,
+			LogLevel:        1,
+			RelayBufferSize: 4 * 1024,
 		}
 	})
 }


### PR DESCRIPTION
支持在配置文件中指定用于转发数据的buffer大小，使用io.Copy时默认buffer大小为32*1024字节，在大多数情况下这个buffer有一点大了，通过pprof分析发现也是这里占用了多一半的内存。

使用 32*1024大小的buffer的内存占用:
![截图_选择区域_20210616163636](https://user-images.githubusercontent.com/16780064/122190952-dfe26480-cec4-11eb-9934-8535c7f8ce55.png)

使用 4*1024大小的buffer的内存占用:
![截图_选择区域_20210616163756](https://user-images.githubusercontent.com/16780064/122192198-03f27580-cec6-11eb-93fe-fae3b5cd8e42.png)

实际测试中，1000并发连接，使用32*1024的buffer内存占用峰值有90-100M,改为4*1024后峰值为30-40M.
@Loyalsoldier @p4gefau1t 
