### PR TITLE
feature: support MySQL TLS Client Key/Certificate

### DIFF
--- a/docs/content/basic/full-config.md
+++ b/docs/content/basic/full-config.md
@@ -108,6 +108,9 @@ weight: 30
     "database": "",
     "username": "",
     "password": "",
+    "key": "/etc/trojan-go/key",
+    "cert": "/etc/trojan-go/cert",
+    "ca": "/etc/trojan-go/ca",
     "check_rate": 60
   },
   "api": {

--- a/statistic/mysql/config.go
+++ b/statistic/mysql/config.go
@@ -11,6 +11,9 @@ type MySQLConfig struct {
 	Database   string `json:"database" yaml:"database"`
 	Username   string `json:"username" yaml:"username"`
 	Password   string `json:"password" yaml:"password"`
+	Key        string `json:"key" yaml:"key"`
+	Cert       string `json:"cert" yaml:"cert"`
+	CA         string `json:"ca" yaml:"ca"`
 	CheckRate  int    `json:"check_rate" yaml:"check-rate"`
 }
 

--- a/statistic/mysql/mysql.go
+++ b/statistic/mysql/mysql.go
@@ -43,10 +43,8 @@ func (a *Authenticator) updater() {
 				log.Error(common.NewError("failed to update data to user table").Base(err))
 				continue
 			}
-			if r, err := s.RowsAffected(); err != nil {
-				if r == 0 {
-					a.DelUser(hash)
-				}
+			if r, err := s.RowsAffected(); err == nil && r == 0 {
+				a.DelUser(hash)
 			}
 		}
 		log.Info("buffered data has been written into the database")


### PR DESCRIPTION
## Summary

Added support for MySQL Client Key/Cert, in alignment with the original `trojan-gfw/trojan` project. 

\* I'm actually a little bit surprised that this feature isn't implemented. If there're any previous discussions and/or related concerns, please let me know. 

Again thanks for a great project.