### PR TITLE
support configurable connect addr rewrite

### DIFF
--- a/tunnel/freedom/client.go
+++ b/tunnel/freedom/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/p4gefau1t/trojan-go/common"
 	"github.com/p4gefau1t/trojan-go/config"
 	"github.com/p4gefau1t/trojan-go/tunnel"
+	"github.com/p4gefau1t/trojan-go/log"
 )
 
 type Client struct {
@@ -51,6 +52,7 @@ func (c *Client) DialConn(addr *tunnel.Address, _ tunnel.Tunnel) (tunnel.Conn, e
 		network = "tcp4"
 	}
 	dialer := new(net.Dialer)
+	log.Debug("Freedom Dial addr" + addr.String())
 	tcpConn, err := dialer.DialContext(c.ctx, network, addr.String())
 	if err != nil {
 		return nil, common.NewError("freedom failed to dial " + addr.String()).Base(err)

--- a/tunnel/transport/config.go
+++ b/tunnel/transport/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	RemoteHost      string                `json:"remote_addr" yaml:"remote-addr"`
 	RemotePort      int                   `json:"remote_port" yaml:"remote-port"`
 	TransportPlugin TransportPluginConfig `json:"transport_plugin" yaml:"transport-plugin"`
+	RewriteConnAddr string                `json:"rewrite_conn_addr" yaml:"rewrite-conn-addr"`
 }
 
 type TransportPluginConfig struct {


### PR DESCRIPTION
支持一个可配的连接覆盖地址，对于CDN场景，允许用户使用自定义的IP与CDN进行连接，而请求中的Host保持remote_addr配置，从而绕行部分CDN只支持NS接入导致无法使用自定义节点的问题